### PR TITLE
End event trigger

### DIFF
--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -41,6 +41,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm run build-web-component
+          npm run build-web-component && npm pack ./web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish ./web-component --access public
+          npm publish project-sunbird-sunbird-epub-player-web-component-* --access public

--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -43,4 +43,4 @@ jobs:
         run: |
           npm run build-web-component && npm pack ./web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish project-sunbird-sunbird-epub-player-web-component-* --access public
+          npm publish jeraldj-sunbird-epub-player-web-component-* --access public

--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -41,6 +41,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm run build-web-component && npm pack ./web-component
+          npm run build-web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish jeraldj-sunbird-epub-player-web-component-* --access public
+          npm publish ./web-component --access public

--- a/projects/sunbird-epub-player/src/lib/epub-viewer/epub-viewer.component.ts
+++ b/projects/sunbird-epub-player/src/lib/epub-viewer/epub-viewer.component.ts
@@ -186,6 +186,9 @@ export class EpubViewerComponent implements OnInit, OnChanges, AfterViewInit, On
   }
 
   ngOnDestroy() {
+    try {
+      this.rendition?.destroy();
+    } catch {}
     this.eBook?.destroy();
   }
 }

--- a/projects/sunbird-epub-player/src/lib/epub-viewer/epub-viewer.component.ts
+++ b/projects/sunbird-epub-player/src/lib/epub-viewer/epub-viewer.component.ts
@@ -1,5 +1,7 @@
-import { AfterViewInit, ViewChild, Component, ElementRef, Input,
-  EventEmitter, Output, OnInit, OnDestroy, SimpleChanges, OnChanges } from '@angular/core';
+import {
+  AfterViewInit, ViewChild, Component, ElementRef, Input,
+  EventEmitter, Output, OnInit, OnDestroy, SimpleChanges, OnChanges
+} from '@angular/core';
 import Epub from 'epubjs';
 import { ViwerService } from '../services/viewerService/viwer-service';
 import { epubPlayerConstants as fromConst } from '../sunbird-epub.constant';
@@ -188,7 +190,9 @@ export class EpubViewerComponent implements OnInit, OnChanges, AfterViewInit, On
   ngOnDestroy() {
     try {
       this.rendition?.destroy();
-    } catch {}
+    } catch (error) {
+      console.error('Failed to destroy EPUB rendition', error);
+    }
     this.eBook?.destroy();
   }
 }

--- a/projects/sunbird-epub-player/src/lib/sunbird-epub-player.component.ts
+++ b/projects/sunbird-epub-player/src/lib/sunbird-epub-player.component.ts
@@ -1,5 +1,7 @@
-import { EventEmitter, Component, Output, Input, OnInit, HostListener,
-  OnDestroy, ElementRef, ViewChild, AfterViewInit, Renderer2, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  EventEmitter, Component, Output, Input, OnInit, HostListener,
+  OnDestroy, ElementRef, ViewChild, AfterViewInit, Renderer2, OnChanges, SimpleChanges
+} from '@angular/core';
 import { ViwerService } from './services/viewerService/viwer-service';
 import { PlayerConfig } from './sunbird-epub-player.interface';
 import { EpubPlayerService } from './sunbird-epub-player.service';
@@ -72,37 +74,37 @@ export class EpubPlayerComponent implements OnInit, OnChanges, OnDestroy, AfterV
   async ngOnInit() {
     this.isInitialized = true;
     if (this.playerConfig) {
-    if (typeof this.playerConfig === 'string') {
-      try {
-        this.playerConfig = JSON.parse(this.playerConfig);
-      } catch (error) {
-        console.error('Invalid playerConfig: ', error);
+      if (typeof this.playerConfig === 'string') {
+        try {
+          this.playerConfig = JSON.parse(this.playerConfig);
+        } catch (error) {
+          console.error('Invalid playerConfig: ', error);
+        }
       }
-    }
-    // initializing services
-    this.viwerService.initialize(this.playerConfig);
-    this.epubPlayerService.initialize(this.playerConfig);
-    this.traceId = this.playerConfig?.config?.traceId;
-    // checks online error while loading epub
-    if (!navigator.onLine && !this.viwerService.isAvailableLocally) {
-      // eslint-disable-next-line max-len
-      this.viwerService.raiseExceptionLog(errorCode.internetConnectivity, this.currentPageIndex, errorMessage.internetConnectivity, this.traceId, new Error(errorMessage.internetConnectivity));
-    }
-
-    // checks content compatibility error
-    const contentCompabilityLevel = this.playerConfig?.metadata?.compatibilityLevel;
-    if (contentCompabilityLevel) {
-      const checkContentCompatible = this.errorService.checkContentCompatibility(contentCompabilityLevel);
-      if (!checkContentCompatible?.isCompitable) {
+      // initializing services
+      this.viwerService.initialize(this.playerConfig);
+      this.epubPlayerService.initialize(this.playerConfig);
+      this.traceId = this.playerConfig?.config?.traceId;
+      // checks online error while loading epub
+      if (!navigator.onLine && !this.viwerService.isAvailableLocally) {
         // eslint-disable-next-line max-len
-        this.viwerService.raiseExceptionLog(errorCode.contentCompatibility, this.currentPageIndex, errorCode.contentCompatibility, this.traceId, checkContentCompatible.error);
+        this.viwerService.raiseExceptionLog(errorCode.internetConnectivity, this.currentPageIndex, errorMessage.internetConnectivity, this.traceId, new Error(errorMessage.internetConnectivity));
       }
-    }
 
-    this.showEpubViewer = true;
-    this.sideMenuConfig = { ...this.sideMenuConfig, ...this.playerConfig.config.sideMenu };
-    this.getEpubLoadingProgress();
-  }
+      // checks content compatibility error
+      const contentCompabilityLevel = this.playerConfig?.metadata?.compatibilityLevel;
+      if (contentCompabilityLevel) {
+        const checkContentCompatible = this.errorService.checkContentCompatibility(contentCompabilityLevel);
+        if (!checkContentCompatible?.isCompitable) {
+          // eslint-disable-next-line max-len
+          this.viwerService.raiseExceptionLog(errorCode.contentCompatibility, this.currentPageIndex, errorCode.contentCompatibility, this.traceId, checkContentCompatible.error);
+        }
+      }
+
+      this.showEpubViewer = true;
+      this.sideMenuConfig = { ...this.sideMenuConfig, ...this.playerConfig.config.sideMenu };
+      this.getEpubLoadingProgress();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -208,11 +210,11 @@ export class EpubPlayerComponent implements OnInit, OnChanges, OnDestroy, AfterV
   }
 
   exitContent(event) {
-    const EndEvent = {
+    const endEvent = {
       type: this.fromConst.END,
       data: { index: this.currentPageIndex }
     };
-    this.viwerService.raiseEndEvent(EndEvent);
+    this.viwerService.raiseEndEvent(endEvent);
     this.viwerService.raiseHeartBeatEvent(event, telemetryType.INTERACT);
   }
 

--- a/projects/sunbird-epub-player/src/lib/sunbird-epub-player.component.ts
+++ b/projects/sunbird-epub-player/src/lib/sunbird-epub-player.component.ts
@@ -208,6 +208,11 @@ export class EpubPlayerComponent implements OnInit, OnChanges, OnDestroy, AfterV
   }
 
   exitContent(event) {
+    const EndEvent = {
+      type: this.fromConst.END,
+      data: { index: this.currentPageIndex }
+    };
+    this.viwerService.raiseEndEvent(EndEvent);
     this.viwerService.raiseHeartBeatEvent(event, telemetryType.INTERACT);
   }
 

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@project-sunbird/sunbird-epub-player-web-component",
+  "name": "@jeraldj/sunbird-epub-player-web-component",
   "version": "2.0.0",
   "description": "The web component package for the sunbird epub player",
   "main": "assets/epub-player/sunbird-epub-player.js",

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jeraldj/sunbird-epub-player-web-component",
-  "version": "2.0.0",
+  "name": "@project-sunbird/sunbird-epub-player-web-component",
+  "version": "2.0.1",
   "description": "The web component package for the sunbird epub player",
   "main": "assets/epub-player/sunbird-epub-player.js",
   "scripts": {


### PR DESCRIPTION
Changes in the Player Repositories (The "Emission" Fix)
a. Synchronous END Event: exitContent and ngOnDestroy ogic in the PDF, ePub, and Video players to explicitly and synchronously call raiseEndEvent()
b. Previously, they depended on logic that could be safely executed in a browser but was too slow/fragile for a mobile "Hardware Back" navigation.
c. Epubjs Cleanup: 
In the ePub player, epubjs (the underlying library) uses a Rendition object to handle the actual display and pagination of the book.

When we call rendition.destroy(), it performs several critical "cleanup" tasks:

Detaches Global Listeners: By default, epubjs adds a listener to the global window object to detect resize and orientation change events. It does this so it can re-calculate the book's layout (fonts, columns, etc.) if you rotate your phone.
Stops Background Logic: It clears any internal timers, pagination calculations, or pending layout tasks.
Removes the Iframe: It safely removes the internal <iframe> used to render the book content.
Why it fixed the "TypeError" and Telemetry Loss:
In your mobile app, when you click the Back button, two things happen at the exact same time:

The player component starts unmounting (removing its code from memory).
The ScreenOrientation.unlock() triggers, causing the device to rotate back to portrait.
Without rendition.destroy(): The global "resize" listener inside epubjs would stay active for a split second after the player started unmounting. When the phone rotated, that listener would wake up and try to re-calculate the layout. But since the player's DOM elements were already being deleted, epubjs would try to access something that no longer existed (like the .length of a list of pages), causing the TypeError.

Because this error happened right in the middle of the "teardown" process, it would "crash" the local Javascript thread, preventing the player from ever reaching the code that sends the END telemetry event.

With rendition.destroy(): We explicitly kill those "zombie" listeners at the very start of the unmount process. Even if the phone rotates half a millisecond later, epubjs is no longer listening, there is no crash, and the telemetry code can finish its job successfully.