### PR TITLE
chore: add Dependabot and dependency-submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+version: 2
+updates:
+  # Root workspace — Angular workspace config, dev tooling, and shared deps
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+          - "@types/jasmine*"
+          - "@types/jasminewd2"
+      types:
+        patterns:
+          - "@types/*"
+
+  # Library package — the publishable Angular library (projects/sunbird-epub-player)
+  - package-ecosystem: "npm"
+    directory: "/projects/sunbird-epub-player"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+
+  # Web component build — standalone ES module distribution
+  - package-ecosystem: "npm"
+    directory: "/web-component"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,67 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-epub-player/package.json'
+      - 'projects/sunbird-epub-player/package-lock.json'
+      - 'web-component/package.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-epub-player/package.json'
+      - 'projects/sunbird-epub-player/package-lock.json'
+      - 'web-component/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-library:
+    name: Submit npm (projects/sunbird-epub-player)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./projects/sunbird-epub-player
+
+  submit-npm-web-component:
+    name: Submit npm (web-component)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No lock file in web-component/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: web-component
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./web-component


### PR DESCRIPTION
Summary                                                
         
  - Enables Dependabot for automated weekly dependency updates across all three npm workspaces (root, projects/sunbird-epub-player, web-component) and for GitHub Actions workflow
  versions.                                                                                                                                                                           
  - Adds a dependency-submission workflow that populates the GitHub Dependency Graph before Dependabot runs, ensuring accurate vulnerability scanning across all package manifests.
  - Uses grouped updates (Angular, Sunbird, Karma/testing, @types) to reduce PR noise and keep related bumps in a single PR.                                                          
                                                                                                                                                                                      
  Changes                                                                                                                                                                             
                                                                                                                                                                                      
  - .github/dependabot.yml — configures 4 update targets: npm root, npm library, npm web-component, and github-actions; all scheduled weekly on Monday at 03:30 UTC with              
  chore(deps)/chore(ci) commit prefixes and dependency grouping.
  - .github/workflows/dependency-submission.yml — runs three parallel jobs to submit npm dependency snapshots for root, library, and web-component directories; triggers on push/PR to
   main when lock files change and on a weekly cron (03:00 UTC, 30 min before Dependabot).                                                                                            
  
  How to Test                                                                                                                                                                         
                                                         
  1. Merge the PR and navigate to Settings → Security → Code security and analysis on the GitHub repo — the Dependency Graph should show entries for all three workspaces.            
  2. On the Monday after merge, verify a Dependabot PR (if any updates exist) is opened with the dependencies label and a grouped commit message like chore(deps): bump ....
  3. Manually trigger the Dependency Submission workflow via Actions → Dependency Submission → Run workflow and confirm all three jobs (Submit npm (root), Submit npm                 
  (projects/sunbird-epub-player), Submit npm (web-component)) complete successfully.                                                                                                  
                                                                                                                                                                                      
  Checklist                                                                                                                                                                           
                                                         
  - Tests added or updated                                                                                                                                                            
  - Documentation updated (if public API or behavior changed)
  - No breaking changes — or breaking changes noted with ! in title and explained in Summary                                                                                          
  - Reviewed my own diff before requesting review                                                                                                                                     